### PR TITLE
Serial static aggregation 

### DIFF
--- a/src/execution/compiler/compiler.cpp
+++ b/src/execution/compiler/compiler.cpp
@@ -8,6 +8,7 @@
 #include "execution/sema/sema.h"
 #include "execution/vm/bytecode_generator.h"
 #include "execution/vm/module.h"
+#include <iostream>
 
 namespace terrier::execution::compiler {
 
@@ -97,6 +98,7 @@ void Compiler::Run(Compiler::Callbacks *callbacks) {
   }
 
   callbacks->EndPhase(Phase::BytecodeGeneration, this);
+  ast::AstPrettyPrint::Dump(std::cerr, root_);
 
   // -------------------------------------------------------
   // Phase 4 : Module Generation

--- a/src/execution/compiler/operator/static_aggregation_translator.cpp
+++ b/src/execution/compiler/operator/static_aggregation_translator.cpp
@@ -22,6 +22,9 @@ StaticAggregationTranslator::StaticAggregationTranslator(const planner::Aggregat
       build_pipeline_(this, Pipeline::Parallelism::Parallel) {
   TERRIER_ASSERT(plan.GetGroupByTerms().empty(), "Global aggregations shouldn't have grouping keys");
   TERRIER_ASSERT(plan.GetChildrenSize() == 1, "Global aggregations should only have one child");
+  // Make the Pipeline serial
+  pipeline->UpdateParallelism(Pipeline::Parallelism::Serial);
+
   // The produce-side is serial since it only generates one output tuple.
   pipeline->RegisterSource(this, Pipeline::Parallelism::Serial);
 

--- a/src/execution/compiler/operator/static_aggregation_translator.cpp
+++ b/src/execution/compiler/operator/static_aggregation_translator.cpp
@@ -19,7 +19,7 @@ StaticAggregationTranslator::StaticAggregationTranslator(const planner::Aggregat
       agg_payload_type_(GetCodeGen()->MakeFreshIdentifier("AggPayload")),
       agg_values_type_(GetCodeGen()->MakeFreshIdentifier("AggValues")),
       merge_func_(GetCodeGen()->MakeFreshIdentifier("MergeAggregates")),
-      build_pipeline_(this, Pipeline::Parallelism::Parallel) {
+      build_pipeline_(this, Pipeline::Parallelism::Serial) {
   TERRIER_ASSERT(plan.GetGroupByTerms().empty(), "Global aggregations shouldn't have grouping keys");
   TERRIER_ASSERT(plan.GetChildrenSize() == 1, "Global aggregations should only have one child");
   // Make the Pipeline serial

--- a/src/execution/compiler/pipeline.cpp
+++ b/src/execution/compiler/pipeline.cpp
@@ -31,6 +31,7 @@ Pipeline::Pipeline(CompilationContext *ctx)
              [this](CodeGen *codegen) { return codegen_->MakeExpr(state_var_); }) {}
 
 Pipeline::Pipeline(OperatorTranslator *op, Pipeline::Parallelism parallelism) : Pipeline(op->GetCompilationContext()) {
+  UpdateParallelism(parallelism);
   RegisterStep(op);
 }
 


### PR DESCRIPTION
The serial pipeline printout is : 

```



struct OutputStruct {
    out0: Integer
}
struct AggPayload {
    agg_term_attr0: CountAggregate
}
struct AggValues {
    agg_term_attr0: Integer
}
struct QueryState {
    execCtx: *ExecutionContext
    aggs   : AggPayload
}
struct P2_State {
    
}
struct P1_State {
    
}
fun Query3_Init(queryState: *QueryState) -> nil {
    return
}

fun Query3_Pipeline2_InitPipelineState(queryState: *QueryState, pipelineState: *P2_State) -> nil {
    return
}

fun Query3_Pipeline2_TearDownPipelineState(queryState: *QueryState, pipelineState: *P2_State) -> nil {
    return
}

fun Query3_Pipeline2_SerialWork(queryState: *QueryState, pipelineState: *P2_State) -> nil {
    var tviBase: TableVectorIterator
    var tvi = &tviBase
    var col_oids: [1]uint32
    col_oids[0] = 2
    @tableIterInit(tvi, queryState.execCtx, 1002, col_oids)
    var slot: TupleSlot
    for (@tableIterAdvance(tvi)) {
        var vpi = @tableIterGetVPI(tvi)
        for (; @vpiHasNext(vpi); @vpiAdvance(vpi)) {
            slot = @vpiGetSlot(vpi)
            var aggValues: AggValues
            aggValues.agg_term_attr0 = @vpiGetInt(vpi, 0)
            @aggAdvance(&queryState.aggs.agg_term_attr0, &aggValues.agg_term_attr0)
        }
    }
    @tableIterClose(tvi)
    return
}

fun Query3_Pipeline2_Init(queryState: *QueryState) -> nil {
    var threadStateContainer = @execCtxGetTLS(queryState.execCtx)
    @tlsReset(threadStateContainer, @sizeOf(P2_State), Query3_Pipeline2_InitPipelineState, Query3_Pipeline2_TearDownPipelineState, queryState)
    return
}

fun Query3_Pipeline2_Run(queryState: *QueryState) -> nil {
    @aggInit(&queryState.aggs.agg_term_attr0)
    var pipelineState = @ptrCast(*P2_State, @tlsGetCurrentThreadState(@execCtxGetTLS(queryState.execCtx)))
    @execCtxStartResourceTracker(queryState.execCtx, 4)
    Query3_Pipeline2_SerialWork(queryState, pipelineState)
    @execCtxEndPipelineTracker(queryState.execCtx, 3, 2)
    return
}

fun Query3_Pipeline2_TearDown(queryState: *QueryState) -> nil {
    @tlsClear(@execCtxGetTLS(queryState.execCtx))
    return
}

fun Query3_Pipeline1_InitPipelineState(queryState: *QueryState, pipelineState: *P1_State) -> nil {
    return
}

fun Query3_Pipeline1_TearDownPipelineState(queryState: *QueryState, pipelineState: *P1_State) -> nil {
    return
}

fun Query3_Pipeline1_SerialWork(queryState: *QueryState, pipelineState: *P1_State) -> nil {
    var aggRow = &queryState.aggs
    var outRow = @ptrCast(*OutputStruct, @resultBufferAllocRow(queryState.execCtx))
    outRow.out0 = @aggResult(&aggRow.agg_term_attr0)
    return
}

fun Query3_Pipeline1_Init(queryState: *QueryState) -> nil {
    var threadStateContainer = @execCtxGetTLS(queryState.execCtx)
    @tlsReset(threadStateContainer, @sizeOf(P1_State), Query3_Pipeline1_InitPipelineState, Query3_Pipeline1_TearDownPipelineState, queryState)
    return
}

fun Query3_Pipeline1_Run(queryState: *QueryState) -> nil {
    var pipelineState = @ptrCast(*P1_State, @tlsGetCurrentThreadState(@execCtxGetTLS(queryState.execCtx)))
    @execCtxStartResourceTracker(queryState.execCtx, 4)
    Query3_Pipeline1_SerialWork(queryState, pipelineState)
    @resultBufferFinalize(queryState.execCtx)
    @execCtxEndPipelineTracker(queryState.execCtx, 3, 1)
    return
}

fun Query3_Pipeline1_TearDown(queryState: *QueryState) -> nil {
    @tlsClear(@execCtxGetTLS(queryState.execCtx))
    return
}

fun Query3_TearDown(queryState: *QueryState) -> nil {
    return
}
```


